### PR TITLE
Add image and workflow to build beta compiler

### DIFF
--- a/.github/workflows/build_compiler_beta.yml
+++ b/.github/workflows/build_compiler_beta.yml
@@ -1,0 +1,29 @@
+name: Publish compiler docker image for beta testnet
+
+on:
+  workflow_dispatch:
+    branches:
+      - 'main'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: [self-hosted, CI-worker]
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        run: |
+          cd images/compiler-beta
+          echo "$SSH_KEY" > key.ssh
+          DOCKER_BUILDKIT=1 docker build --no-cache --progress=plain --secret id=ssh_key,src=key.ssh -t zksyncrobot/test-build . 
+          docker push zksyncrobot/test-build:latest
+        env:
+          SSH_KEY: ${{secrets.SSH_KEY}}

--- a/images/compiler-beta/Dockerfile
+++ b/images/compiler-beta/Dockerfile
@@ -1,0 +1,61 @@
+FROM matterlabs/llvm_runner:latest as builder 
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+RUN mkdir -p /home/docker/.ssh
+RUN --mount=type=secret,id=ssh_key cp /run/secrets/ssh_key /home/docker/.ssh/id_rsa 
+
+RUN echo "Host github.com\n\tStrictHostKeyChecking no\n" >> /home/docker/.ssh/config
+RUN chown -R docker:docker /home/docker/.ssh
+RUN chown -R docker:docker /usr/local/cargo
+
+USER docker 
+
+WORKDIR /home/docker/
+
+# Obtain `solc` 0.8.10.
+RUN wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.10%2Bcommit.fc410830 \
+    && mv solc-linux-amd64-v0.8.10+commit.fc410830 solc \
+    && chmod +x solc
+
+# Download LLVM and build it.
+RUN git clone --depth 1 --branch main git@github.com:matter-labs/compiler-llvm.git
+
+# TODO: We can't use `./build.sh release`, since it has `sudo` command which fails.
+#       Currently it's a copy-paste from `./build.sh` with `sudo make install` replaced by `make install`.
+WORKDIR /home/docker/compiler-llvm
+ENV DIRECTORY_SUFFIX='release'
+ENV BUILD_TYPE='Release'
+ENV LLVM_VERSION=13
+RUN cmake \
+            -S 'llvm' \
+            -B "../build-${DIRECTORY_SUFFIX}/" \
+            -G 'Unix Makefiles' \
+            -DCMAKE_INSTALL_PREFIX="${HOME}/opt/llvm-${DIRECTORY_SUFFIX}/" \
+            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+            -DCMAKE_C_COMPILER="clang-${LLVM_VERSION}" \
+            -DCMAKE_CXX_COMPILER="clang++-${LLVM_VERSION}" \
+            -DLLVM_TARGETS_TO_BUILD='X86' \
+            -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='SyncVM' \
+            -DLLVM_OPTIMIZED_TABLEGEN='On' \
+            -DLLVM_USE_LINKER="lld-${LLVM_VERSION}" \
+            -DLLVM_BUILD_DOCS='Off' \
+            -DLLVM_INCLUDE_DOCS='Off' \
+            -DLLVM_ENABLE_DOXYGEN='Off' \
+            -DLLVM_ENABLE_SPHINX='Off' \
+            -DLLVM_ENABLE_OCAMLDOC='Off' \
+            -DLLVM_ENABLE_BINDINGS='Off' \
+            && cd ../build-${DIRECTORY_SUFFIX}/ \
+            && make -j "$(nproc)" \
+            && make install
+
+# Download zksolc and build it.
+WORKDIR /home/docker/
+RUN git clone --depth 1 --branch main git@github.com:matter-labs/compiler-solidity.git \
+    && cd compiler-solidity \
+    && ./run.sh info release
+
+
+FROM debian:buster-slim
+
+COPY --from=builder /home/docker/compiler-solidity/target/release/zksolc /usr/local/bin/
+COPY --from=builder /home/docker/solc /usr/local/bin/
+CMD ["zksolc"]


### PR DESCRIPTION
Provides a separate image to build the compiler to be used by actual developers.
It is also adapted for the latest changes in the compiler.

It uses the intentionally obscure container name "zksyncrobot/test-build" for now (until we publicly announce the compiler).
