### PR TITLE
Fix `PATH` and `LD_LIBRARY_PATH`

### DIFF
--- a/images/llvm_runner/Dockerfile
+++ b/images/llvm_runner/Dockerfile
@@ -30,7 +30,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get --yes install python3.9 python3.9-dev python3.9-distutils
 
-ENV PATH=/usr/local/clang_13/bin:$PATH \
-    D_LIBRARY_PATH=/usr/local/clang_13/lib:$LD_LIBRARY_PATH \
+ENV PATH=/usr/lib/llvm-13/bin:$PATH \
+    LD_LIBRARY_PATH=/usr/lib/llvm-13/lib:$LD_LIBRARY_PATH \
     LLVM_VERSION=13 \
     CI_RUNNING=true


### PR DESCRIPTION
For some reason, `clang`, `clang++` and all LLVM libs weren't in PATH.