### PR TITLE
Removed libcvc4-dev

### DIFF
--- a/.github/workflows/handle_llvm_runner_image.yml
+++ b/.github/workflows/handle_llvm_runner_image.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ matrix.image_name == 'llvm_runner_jammy' && 'linux/amd64,linux/arm64,linux/arm64/v8' || 'linux/amd64' }}
+          platforms: 'linux/amd64,linux/arm64,linux/arm64/v8'
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push'
@@ -77,4 +77,4 @@ jobs:
             matterlabs/${{ matrix.image_name }}:${{ steps.set_output.outputs.sha_short }}
             matterlabs/${{ matrix.image_name }}:latest
           file: images/llvm_runner/${{ matrix.image_name == 'llvm_runner_jammy' && 'jammy.' || '' }}Dockerfile
-          platforms: ${{ matrix.image_name == 'llvm_runner_jammy' && 'linux/amd64,linux/arm64,linux/arm64/v8' || 'linux/amd64' }}
+          platforms: 'linux/amd64,linux/arm64,linux/arm64/v8'


### PR DESCRIPTION
We have to remove libcvc4-dev lib as it absent for the focal arm64 distro. This lib is not require during the build and runtime.