### PR TITLE
feat: add valgrind support to all images

### DIFF
--- a/images/llvm_runner/Dockerfile
+++ b/images/llvm_runner/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     software-properties-common jq \
     openssh-client git \
     build-essential \
-    libncurses5 xz-utils wget gnupg musl-tools && \
+    libncurses5 xz-utils wget gnupg musl-tools valgrind && \
     rm -rf /var/lib/apt/lists/*
 
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/images/llvm_runner/jammy.Dockerfile
+++ b/images/llvm_runner/jammy.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     software-properties-common jq \
     openssh-client git \
     build-essential \
-    libncurses5 xz-utils wget gnupg musl-tools && \
+    libncurses5 xz-utils wget gnupg musl-tools valgrind && \
     rm -rf /var/lib/apt/lists/*
 
 # Set gcc-9 as default for old compiler builds


### PR DESCRIPTION
## What?

Add `valgrind` support to both images.

## Why?

To allow memory profiling in CI for the compilers team.