### PR TITLE
chore: add libc6-dbg package to fix valgrind on x86_64

### DIFF
--- a/images/zksync-llvm-runner/Dockerfile
+++ b/images/zksync-llvm-runner/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
     libz3-dev=4.8.* \
     file=1:5.* \
     nano=6.* \
+    libc6-dbg=2.35* \
     && rm -rf /var/lib/apt/lists/*
 
 # Install LLVM


### PR DESCRIPTION
## What?

Fix `valgrind` issue on x86_64 platform:
```
valgrind:  Fatal error at startup: a function redirection
valgrind:  which is mandatory for this platform-tool combination
valgrind:  cannot be set up.  Details of the redirection are:
valgrind:  
valgrind:  A must-be-redirected function
valgrind:  whose name matches the pattern:      strcmp
valgrind:  in an object with soname matching:   ld-linux-x86-64.so.2
valgrind:  was not found whilst processing
valgrind:  symbols from the object with soname: ld-linux-x86-64.so.2
```

[Issue full logs](https://github.com/matter-labs/era-compiler-llvm/actions/runs/10700719936/job/29665130020)

Tested locally to prove it works after that.