### PR TITLE
feat: update stable rust from 1.82 to 1.84

### DIFF
--- a/images/zksync-llvm-runner/Dockerfile
+++ b/images/zksync-llvm-runner/Dockerfile
@@ -74,7 +74,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     CARGO_NET_GIT_FETCH_WITH_CLI=true \
     PATH=/usr/local/cargo/bin:$PATH
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y
 
 # Set required environment variables
 ENV PATH=/usr/lib/llvm-${LLVM_VERSION}/bin:${PATH} \


### PR DESCRIPTION
Stable Rust toolchain updated from 1.82 to 1.84, update the docker image to reinstall Rust.