### PR TITLE
fix: move llvm dev container to LLVM 20

### DIFF
--- a/images/zksync-llvm-runner/Dockerfile
+++ b/images/zksync-llvm-runner/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install LLVM
-ENV LLVM_VERSION=19
+ENV LLVM_VERSION=20
 RUN curl https://apt.llvm.org/llvm.sh -sSf | bash -s -- ${LLVM_VERSION} all && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Required to properly merge code coverage reports from integration tests.